### PR TITLE
Frontend voice input for AI transcription

### DIFF
--- a/islands/core/buttons/VoiceRecordButton.tsx
+++ b/islands/core/buttons/VoiceRecordButton.tsx
@@ -102,11 +102,11 @@ function VoiceRecordButton({
         };
 
         mediaRecorder.onstop = async () => {
-          const audioBlob = new Blob(audioChunksRef.current, {
-            type: "audio/wav",
-          });
+          // Use the actual recorder mime type if available; otherwise, let the browser infer
+          const mimeType = mediaRecorderRef.current?.mimeType || undefined;
+          const audioBlob = new Blob(audioChunksRef.current, mimeType ? { type: mimeType } : undefined);
           audioChunksRef.current = [];
-          await sendAudioToServer(audioBlob);
+          await transcribeAudio(audioBlob);
         };
 
         mediaRecorder.start();
@@ -117,14 +117,55 @@ function VoiceRecordButton({
     }
   }
 
-  const sendAudioToServer = async (audioBlob: Blob) => {
-    const formData = new FormData();
-    formData.append("audio", audioBlob, "recording.wav");
+  const transcribeDirect = async (audioBlob: Blob): Promise<string | null> => {
+    try {
+      const serverUrl = settings.peek().sttUrl || "";
+      let modelName = settings.peek().sttModel || "";
+      const sttKey = settings.peek().sttKey || "";
 
-    console.log(settings.peek());
-    let serverUrl = settings.peek().sttUrl;
-    let modelName = settings.peek().sttModel;
-    const sttKey = settings.peek().sttKey;
+      if (!serverUrl || !sttKey) return null; // signal to fallback
+
+      // Apply GROQ defaults if key indicates GROQ
+      if (sttKey.startsWith("gsk_")) {
+        modelName = modelName === "" ? "whisper-large-v3-turbo" : modelName;
+      }
+
+      const sttFormData = new FormData();
+      sttFormData.append("file", audioBlob, "recording.webm");
+      sttFormData.append("model", modelName || "whisper-1");
+
+      const resp = await fetch(serverUrl, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${sttKey}`,
+        },
+        body: sttFormData,
+      });
+
+      if (!resp.ok) {
+        // Let caller decide to fallback
+        console.warn("Direct STT call failed with status", resp.status);
+        return null;
+      }
+
+      // Most STT endpoints return JSON with { text }
+      const data = await resp.json().catch(async () => ({ text: await resp.text() }));
+      const text = typeof data === "string" ? data : (data?.text ?? "");
+      return text || "";
+    } catch (err) {
+      console.warn("Direct STT call errored; will fallback:", err);
+      return null;
+    }
+  };
+
+  const transcribeViaProxy = async (audioBlob: Blob): Promise<string> => {
+    const formData = new FormData();
+    formData.append("audio", audioBlob, "recording.webm");
+
+    const sttSettings = settings.peek();
+    let serverUrl = sttSettings.sttUrl;
+    let modelName = sttSettings.sttModel;
+    const sttKey = sttSettings.sttKey;
 
     if (sttKey.startsWith("gsk_")) {
       serverUrl = serverUrl === ""
@@ -138,27 +179,34 @@ function VoiceRecordButton({
     formData.append("sttModel", modelName);
     formData.append("shopApiKey", shopApiKey);
 
-    try {
-      const response = await fetch("/api/stt", {
-        method: "POST",
-        body: formData,
-      });
+    const response = await fetch("/api/stt", {
+      method: "POST",
+      body: formData,
+    });
 
-      if (response.ok) {
-        console.log("Audio uploaded successfully");
-        const text = await response.text();
-        console.log("Text from VoiceRecordButton:", text);
-        onFinishRecording(text);
-      } else {
-        console.error("Failed to upload audio");
-        const errorMessage = await response.text();
-        addMessage({
-          role: "assistant",
-          content: `❌ **Error**: ${errorMessage}`,
-        });
-      }
+    if (!response.ok) {
+      const errorMessage = await response.text();
+      throw new Error(errorMessage || "Failed to upload audio");
+    }
+
+    return await response.text();
+  };
+
+  const transcribeAudio = async (audioBlob: Blob) => {
+    console.log(settings.peek());
+
+    try {
+      // Try direct call first if STT URL + Key are configured (frontend-only)
+      const directText = await transcribeDirect(audioBlob);
+      const text = directText ?? await transcribeViaProxy(audioBlob);
+      console.log("Text from VoiceRecordButton:", text);
+      onFinishRecording(text);
     } catch (error) {
-      console.error("Error uploading audio:", error);
+      console.error("Error uploading/transcribing audio:", error);
+      addMessage({
+        role: "assistant",
+        content: `❌ **Error**: ${error instanceof Error ? error.message : "Unknown error during transcription"}`,
+      });
     }
   };
 

--- a/static/audio-button.ts
+++ b/static/audio-button.ts
@@ -263,7 +263,8 @@ export class AudioButton extends HTMLElement {
       };
 
       this.mediaRecorder.onstop = async () => {
-        const audioBlob = new Blob(this.audioChunks, { type: "audio/wav" });
+        const mimeType = this.mediaRecorder?.mimeType || undefined;
+        const audioBlob = new Blob(this.audioChunks, mimeType ? { type: mimeType } : undefined);
         await this.sendAudioToServer(audioBlob);
       };
 
@@ -284,26 +285,53 @@ export class AudioButton extends HTMLElement {
   }
 
   private async sendAudioToServer(audioBlob: Blob) {
-    const formData = new FormData();
-    formData.append("audio", audioBlob, "recording.wav");
-    formData.append("sttUrl", this.config.sttUrl || "");
-    formData.append("sttKey", this.config.sttKey || "");
-    formData.append("sttModel", this.config.sttModel || "");
+    const tryDirect = async (): Promise<string | null> => {
+      try {
+        const serverUrl = this.config.sttUrl || "";
+        const sttKey = this.config.sttKey || "";
+        let modelName = this.config.sttModel || "";
+        if (!serverUrl || !sttKey) return null;
+        if (sttKey.startsWith("gsk_")) {
+          modelName = modelName || "whisper-large-v3-turbo";
+        }
+        const fd = new FormData();
+        fd.append("file", audioBlob, "recording.webm");
+        fd.append("model", modelName || "whisper-1");
+        const resp = await fetch(serverUrl, {
+          method: "POST",
+          headers: { Authorization: `Bearer ${sttKey}` },
+          body: fd,
+        });
+        if (!resp.ok) return null;
+        const data = await resp.json().catch(async () => ({ text: await resp.text() }));
+        const text = typeof data === "string" ? data : (data?.text ?? "");
+        return text || "";
+      } catch (_e) {
+        return null;
+      }
+    };
 
-    try {
+    const tryProxy = async (): Promise<string> => {
+      const formData = new FormData();
+      formData.append("audio", audioBlob, "recording.webm");
+      formData.append("sttUrl", this.config.sttUrl || "");
+      formData.append("sttKey", this.config.sttKey || "");
+      formData.append("sttModel", this.config.sttModel || "");
+
       const response = await fetch("/api/stt", {
         method: "POST",
         body: formData,
       });
+      if (!response.ok) throw new Error(await response.text());
+      return await response.text();
+    };
 
-      if (response.ok) {
-        const text = await response.text();
-        this.dispatchEvent(new CustomEvent("transcription", { detail: text }));
-      } else {
-        console.error("Failed to upload audio");
-      }
+    try {
+      const directText = await tryDirect();
+      const text = directText ?? await tryProxy();
+      this.dispatchEvent(new CustomEvent("transcription", { detail: text }));
     } catch (error) {
-      console.error("Error uploading audio:", error);
+      console.error("Failed to transcribe audio:", error);
     }
   }
 


### PR DESCRIPTION
Enable frontend-only voice input for AI transcription with automatic fallback to server proxy.

This allows direct transcription calls to configured STT endpoints from the browser, reducing server load. The system automatically falls back to the existing `/api/stt` server proxy if the direct call fails (e.g., due to CORS or missing configuration). Users can enable this by setting the STT Key, URL, and Model in their settings.

---
<a href="https://cursor.com/background-agent?bcId=bc-9f9048b2-889d-4686-8d0d-29e5bd8ffaba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9f9048b2-889d-4686-8d0d-29e5bd8ffaba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

